### PR TITLE
chore(ujust): Improve setup-virtualization user experience (#1237)

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/bazzite-libvirtd-setup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/bazzite-libvirtd-setup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Enable libvirtd service after reboot
+After=local-fs.target
+ConditionPathExists=/usr/lib/systemd/system/libvirtd.service
+
+[Service]
+Type=oneshot
+# TODO: Rewrite this whenever systemd allows to queue ephemeral commands for next boot without modifying kernel args
+ExecStart=/usr/bin/bash -c "systemctl enable --now libvirtd; systemctl disable %n"
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -41,29 +41,34 @@ setup-virtualization ACTION="":
       )
     fi
     if [[ "${OPTION,,}" =~ (^enable[[:space:]]virtualization|virt-on) ]]; then
-      virt_test=$(rpm-ostree status | grep -A 4 "●" | grep "virt-manager")
-      if [[ -z ${virt_test} ]]; then
-        echo "Installing QEMU and virt-manager..."
-        rpm-ostree install -y virt-manager edk2-ovmf qemu
-        rpm-ostree kargs \
-        --append-if-missing="kvm.ignore_msrs=1" \
-        --append-if-missing="kvm.report_ignored_msrs=0"
-        echo 'Please re-run "ujust setup-virtualization" after the reboot to enable libvirtd service'
-      fi
-    elif [[ "${OPTION,,}" =~ (^disable[[:space:]]virtualization|virt-off) ]]; then
-      virt_test=$(rpm-ostree status | grep -A 4 "●" | grep "virt-manager")
-      if [[ ${virt_test} ]]; then
-        if [ "$(systemctl is-enabled libvirtd.service)" == "enabled" ]; then
-          echo "${red}Disabling${n} libvirtd before removal"
-          sudo systemctl disable --now libvirtd 2> /dev/null
+      (
+        virt_test=$(rpm-ostree status -v --jsonpath '.deployments[0].packages')
+        if [[ ${virt_test} == *virt-manager* ]]; then
+          echo "Installing QEMU and virt-manager..."
+          rpm-ostree install -y virt-manager edk2-ovmf qemu
+          rpm-ostree kargs \
+          --append-if-missing="kvm.ignore_msrs=1" \
+          --append-if-missing="kvm.report_ignored_msrs=0"
+          sudo systemctl enable bazzite-libvirtd-setup.service \
+            && echo "libvirtd will be enabled at next reboot"
+          echo 'Please reboot to apply changes'
         fi
-        echo "Removing QEMU and virt-manager..."
-        rpm-ostree remove -y virt-manager edk2-ovmf qemu
-        rpm-ostree kargs \
-        --delete-if-present="kvm.ignore_msrs=1" \
-        --delete-if-present="kvm.report_ignored_msrs=0"
-        echo 'Please re-run "ujust enable-virtualization" after the reboot to finish setup'
+      )
+    elif [[ "${OPTION,,}" =~ (^disable[[:space:]]virtualization|virt-off) ]]; then
+      if [ "$(systemctl is-enabled libvirtd.service)" == "enabled" ]; then
+        echo "${red}Disabling${n} libvirtd before removal"
+        sudo systemctl disable --now libvirtd 2> /dev/null
       fi
+      if [ "$(systemctl is-enabled bazzite-libvirtd-setup.service)" == "enabled" ]; then
+        echo "${red}Disabling${n} bazzite-libvirtd-setup"
+        sudo systemctl disable --now bazzite-libvirtd-setup.service 2> /dev/null
+      fi
+      echo "Removing QEMU and virt-manager..."
+      rpm-ostree remove -y virt-manager edk2-ovmf qemu
+      rpm-ostree kargs \
+      --delete-if-present="kvm.ignore_msrs=1" \
+      --delete-if-present="kvm.report_ignored_msrs=0"
+      echo 'Please reboot to apply changes'
     elif [[ "${OPTION,,}" =~ (^enable[[:space:]]vfio|vfio-on) ]]; then
       # Check if we are running on a Steam Deck
       if /usr/libexec/hwsupport/valve-hardware; then


### PR DESCRIPTION
* chore(ujust): Improve virt-manager detection at setup-virtualization

* refactor(ujust): isolate temporary var in a subshell

* chore(ujust): Move libvirtd,service enablement logic to service

* Add bazzite-libvirtd-setup.service

* fix(ujust): Replace faulty bazzite-libvirtd-setup.service triggering condition

* chore(ujust): reduce grep usage in setup-virtualization

* chore(ujust): add missing sudo call

* chore(ujust): remove unnecessary check in disable-virtualization

rpm-ostree should remove virtualization related packages/kernel args regardless of virt-manager being installed. rpm-ostree will not generate a commit if no effective change is applied.

* chore(ujust): Disable setup service at disable-virtualization

---------

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
